### PR TITLE
feat(Utility): add prefab creator

### DIFF
--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fa5080c81f6e5043bfe056380de839b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tilia.Locomotors.TeleportTargets.Unity.Editor.asmdef
+++ b/Editor/Tilia.Locomotors.TeleportTargets.Unity.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Tilia.Locomotors.TeleportTargets.Unity.Editor",
+    "references": [
+        "Zinnia.Editor"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Editor/Tilia.Locomotors.TeleportTargets.Unity.Editor.asmdef.meta
+++ b/Editor/Tilia.Locomotors.TeleportTargets.Unity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9556302e445b21f418e3d01a689554c8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility.meta
+++ b/Editor/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1f7f83a3ff779b46a0b02c25bac0ee8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility/PrefabCreator.cs
+++ b/Editor/Utility/PrefabCreator.cs
@@ -1,0 +1,37 @@
+namespace Tilia.Locomotors.TeleportTargets.Utility
+{
+    using System.IO;
+    using UnityEditor;
+    using Zinnia.Utility;
+
+    public class PrefabCreator : BasePrefabCreator
+    {
+        private const string group = "Tilia/";
+        private const string project = "Locomotors/TeleportTargets/";
+        private const string menuItemRoot = topLevelMenuLocation + group + subLevelMenuLocation + project;
+
+        private const string package = "io.extendreality.tilia.locomotors.teleporttargets.unity";
+        private const string baseDirectory = "Runtime";
+        private const string prefabDirectory = "Prefabs";
+        private const string prefabSuffix = ".prefab";
+
+        private const string prefabTeleportTargetsArea = "Locomotors.TeleportTargets.Area";
+        private const string prefabTeleportTargetsPoint = "Locomotors.TeleportTargets.Point";
+
+        [MenuItem(menuItemRoot + prefabTeleportTargetsArea, false, priority)]
+        private static void AddTeleportTargetsArea()
+        {
+            string prefab = prefabTeleportTargetsArea + prefabSuffix;
+            string packageLocation = Path.Combine(packageRoot, package, baseDirectory, prefabDirectory, prefab);
+            CreatePrefab(packageLocation);
+        }
+
+        [MenuItem(menuItemRoot + prefabTeleportTargetsPoint, false, priority)]
+        private static void AddTeleportTargetsPoint()
+        {
+            string prefab = prefabTeleportTargetsPoint + prefabSuffix;
+            string packageLocation = Path.Combine(packageRoot, package, baseDirectory, prefabDirectory, prefab);
+            CreatePrefab(packageLocation);
+        }
+    }
+}

--- a/Editor/Utility/PrefabCreator.cs.meta
+++ b/Editor/Utility/PrefabCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97a61f685555b384dac33a5e8cdbf4f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Weavers>
+  <Malimbe.FodyRunner>
+    <AssemblyNameRegex>^Tilia.Locomotors.TeleportTargets</AssemblyNameRegex>
+  </Malimbe.FodyRunner>
+</Weavers>

--- a/FodyWeavers.xml.meta
+++ b/FodyWeavers.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c8af3fadb59cce4da129dad64489760
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The latest version of Zinnia has the basis of a prefab creator that can
be used to enable easy adding of prefabs to a scene without needing to
drag and drop from directories. Instead a new menu item is added for
quickly adding prefabs. The guide has been updated to accommodate this
and the FodyWeavers.xml is now located in the root to serve both the
Runtime and Editor scripts.