### PR TITLE
fix(package.json): add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
+        "io.extendreality.zinnia.unity": "2.5.0",
         "io.extendreality.tilia.indicators.spatialtargets.unity": "2.0.16"
     },
     "files": [


### PR DESCRIPTION
The Zinnia dependency was not listed but still worked because the spatial targets dependency was including it but really all dependencies should be listed to make it clear what is being depended on.